### PR TITLE
Fix text selection conflict with clickable table rows

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -30,8 +30,8 @@ document.addEventListener('DOMContentLoaded', function() {
       if (links.length > 0) {
         row.style.cursor = 'pointer';
         row.addEventListener('click', function(e) {
-          // Don't trigger if they clicked the actual link
-          if (e.target.tagName !== 'A') {
+          // Don't trigger if they clicked the actual link or if text is selected
+          if (e.target.tagName !== 'A' && window.getSelection().toString().length === 0) {
             links[0].click();
           }
         });


### PR DESCRIPTION
## Summary
- Fixed issue where selecting text in activity report tables would trigger navigation instead of allowing text selection
- Users can now copy PR titles and other table content without accidentally navigating to links

## Test plan
- [x] Navigate to activity report page
- [x] Try selecting text from PR titles in the table
- [x] Verify text can be selected and copied without triggering navigation
- [x] Verify clicking elsewhere in the row still navigates to the PR

🤖 Generated with [Claude Code](https://claude.ai/code)