### PR TITLE
feat: add org/user exclusion filter for activity reports

### DIFF
--- a/routes/activity.js
+++ b/routes/activity.js
@@ -7,6 +7,30 @@ import { updateSessionProgress } from '../lib/progress-tracker.js';
 
 const router = express.Router();
 
+// Filter activity data to exclude repos owned by specified orgs/users
+function filterExcludedOrgs(activity, excludeOrgs) {
+  if (!excludeOrgs || excludeOrgs.length === 0) return activity;
+
+  const excluded = new Set(excludeOrgs.map(o => o.toLowerCase()));
+  const isExcluded = (repo) => {
+    const owner = repo.nameWithOwner.split('/')[0].toLowerCase();
+    return excluded.has(owner);
+  };
+
+  return {
+    pullRequests: activity.pullRequests.filter(pr => !isExcluded(pr.repository)),
+    reviews: activity.reviews.filter(r => !isExcluded(r.repository)),
+    issues: activity.issues.filter(i => !isExcluded(i.repository)),
+    commitsByRepo: activity.commitsByRepo.filter(c => !isExcluded(c.repository)),
+  };
+}
+
+// Parse comma-separated org exclusion string into array
+function parseExcludeOrgs(excludeOrgsStr) {
+  if (!excludeOrgsStr || !excludeOrgsStr.trim()) return [];
+  return excludeOrgsStr.split(',').map(s => s.trim()).filter(Boolean);
+}
+
 // Display form to generate activity report
 router.get('/', async (req, res) => {
   if (!res.locals.hasGithubToken) {
@@ -21,7 +45,8 @@ router.get('/', async (req, res) => {
     title: 'Generate Activity Report',
     username: req.query.username || '',
     startDate: req.query.startDate || '',
-    cachedUsernames: cachedUsernames
+    cachedUsernames: cachedUsernames,
+    excludedOrgs: req.appConfig?.excludedOrgs || []
   });
 });
 
@@ -200,8 +225,9 @@ router.post('/', async (req, res) => {
       `${req.appConfig.githubToken.substring(0, 5)}...${req.appConfig.githubToken.substring(req.appConfig.githubToken.length - 4)}` : 
       'No token');
 
-    const { username, usernames, startDate, enrich, processToken } = req.body;
-    
+    const { username, usernames, startDate, enrich, processToken, excludeOrgs } = req.body;
+    const excludeOrgsList = parseExcludeOrgs(excludeOrgs);
+
     // Process usernames (both from direct field and the hidden comma-separated field)
     let usernameList = [];
     
@@ -259,19 +285,26 @@ router.post('/', async (req, res) => {
         console.log(`Enrichment complete for ${currentUsername}`);
       }
       
+      // Apply org/user exclusion filter
+      const filteredActivity = filterExcludedOrgs(activity, excludeOrgsList);
+
+      if (excludeOrgsList.length > 0) {
+        console.log(`Filtered out repos from: ${excludeOrgsList.join(', ')} for ${currentUsername}`);
+      }
+
       // Generate reports for this user
-      const htmlReport = generateActivityReport(activity, since, currentUsername, 'html', enrich === 'true');
-      const plainTextReport = generateActivityReport(activity, since, currentUsername, 'plain', enrich === 'true');
-      
+      const htmlReport = generateActivityReport(filteredActivity, since, currentUsername, 'html', enrich === 'true');
+      const plainTextReport = generateActivityReport(filteredActivity, since, currentUsername, 'plain', enrich === 'true');
+
       // Store the user data
       usersData.push({
         username: currentUsername,
-        activity,
+        activity: filteredActivity,
         htmlReport,
         plainTextReport
       });
     }
-    
+
     // Generate consolidated report for multi-user case
     let consolidatedHtmlReport = '';
     let consolidatedPlainText = '';
@@ -351,6 +384,7 @@ router.post('/', async (req, res) => {
         username: userData.username,
         activity: userData.activity,
       })),
+      excludedOrgs: excludeOrgsList,
       generatedAt: new Date().toISOString(),
       hasSummary: !!summary
     };

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -106,6 +106,7 @@ router.get('/', async (req, res) => {
     githubToken: config.githubToken || '',
     anthropicKey: config.anthropicKey || '',
     claudeModel: config.claudeModel || 'claude-3-5-sonnet-latest',
+    excludedOrgs: config.excludedOrgs || [],
     storageLocation: config.storageLocation || 'local', // local or home
     claudeModels: availableModels || []
   });
@@ -145,12 +146,18 @@ router.post('/fetch-models', async (req, res) => {
 // Save settings
 router.post('/', async (req, res) => {
   try {
-    const { githubToken, anthropicKey, claudeModel } = req.body;
-    
+    const { githubToken, anthropicKey, claudeModel, excludedOrgs } = req.body;
+
+    // Parse excluded orgs: comma-separated string to array, trimmed and lowercased
+    const parsedExcludedOrgs = excludedOrgs
+      ? excludedOrgs.split(',').map(s => s.trim()).filter(Boolean)
+      : [];
+
     const config = {
       githubToken: githubToken.trim(),
       anthropicKey: anthropicKey.trim(),
-      claudeModel: claudeModel || 'claude-3-5-sonnet-latest'
+      claudeModel: claudeModel || 'claude-3-5-sonnet-latest',
+      excludedOrgs: parsedExcludedOrgs
     };
 
     // Check if GitHub token is valid by making a test request

--- a/views/activity-form.ejs
+++ b/views/activity-form.ejs
@@ -69,6 +69,18 @@
               </div>
             </div>
             
+            <div class="mb-3">
+              <label for="excludeOrgs" class="form-label">Exclude Organizations / Users</label>
+              <input type="text" class="form-control" id="excludeOrgs" name="excludeOrgs"
+                value="<%= (locals.excludedOrgs || []).join(', ') %>"
+                placeholder="e.g., my-org, personal-account"
+                autocomplete="off">
+              <div class="form-text">
+                Comma-separated list of GitHub orgs/users whose repos will be excluded.
+                Pre-filled from <a href="/settings">settings</a>.
+              </div>
+            </div>
+
             <div class="d-grid gap-2 d-md-flex justify-content-md-end">
               <button type="submit" class="btn btn-primary">
                 <i class="bi bi-search me-2"></i>Generate Report

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -72,6 +72,22 @@
           </div>
           
           <div class="mb-4">
+            <h4>Report Filtering</h4>
+            <p class="text-muted">Configure default filters applied when generating reports.</p>
+
+            <div class="mb-3">
+              <label for="excludedOrgs" class="form-label">Excluded Organizations / Users</label>
+              <input type="text" class="form-control" id="excludedOrgs" name="excludedOrgs"
+                value="<%= excludedOrgs.join(', ') %>" placeholder="e.g., my-org, personal-account"
+                autocomplete="off">
+              <div class="form-text">
+                Comma-separated list of GitHub organizations or users whose repositories will be excluded from reports.
+                This can be overridden per-report.
+              </div>
+            </div>
+          </div>
+
+          <div class="mb-4">
             <h5>Storage Location</h5>
             <p class="text-muted">Your credentials will be stored in <code>~/.what-have-i-done/config.json</code></p>
           </div>


### PR DESCRIPTION
## Summary

- Adds the ability to exclude repositories owned by specific GitHub organizations or users when generating activity reports
- Useful for filtering out personal repos (e.g., side projects, personal utilities) when generating reports for paid-work review time
- Configurable as a persistent default in Settings, with per-report override on the activity form

## Changes

- **Settings**: New "Report Filtering" section with "Excluded Organizations / Users" field, persisted to `~/.what-have-i-done/config.json`
- **Activity Form**: New exclusion field pre-populated from settings default, overridable per-report
- **Activity Route**: Filters PRs, reviews, issues, and commits by repo owner (case-insensitive) after fetch/enrichment but before report generation
- **Report Metadata**: Stores the exclusion list used for each saved report

## Test plan

- [ ] Go to Settings, add comma-separated org names, save
- [ ] Go to Activity form, verify the exclusion field is pre-populated from settings
- [ ] Generate a report with exclusions and verify filtered repos are absent from the report
- [ ] Generate a report with the exclusion field cleared to verify all repos appear
- [ ] Verify saved reports include `excludedOrgs` in their JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)